### PR TITLE
avoid checking for import methods in parent classes

### DIFF
--- a/t/02moo.t
+++ b/t/02moo.t
@@ -61,7 +61,7 @@ use if ($] < 5.010), 'UNIVERSAL::DOES';
 
 can_ok('Local::Class1', 'construct_instance');
 ok(
-	!Local::Class1->can('import'),
+	!exists &Local::Class1::import,
 	'Local::Class1 did not accidentally consume an "import" method'
 );
 

--- a/t/03moose.t
+++ b/t/03moose.t
@@ -65,7 +65,7 @@ BEGIN {
 
 can_ok('Local::Class1', 'construct_instance');
 ok(
-	!Local::Class1->can('import'),
+	!exists &Local::Class1::import,
 	'Local::Class1 did not accidentally consume an "import" method'
 );
 

--- a/t/04homebrew.t
+++ b/t/04homebrew.t
@@ -65,7 +65,7 @@ use if ($] < 5.010), 'UNIVERSAL::DOES';
 
 can_ok('Local::Class1', 'construct_instance');
 ok(
-	!Local::Class1->can('import'),
+	!exists &Local::Class1::import,
 	'Local::Class1 did not accidentally consume an "import" method'
 );
 


### PR DESCRIPTION
Since we're checking for a import method getting installed, it makes sense to check for it directly in the namespace and ignoring parent classes.

Future versions of perl are intending to have a real UNIVERSAL::import method rather than a magic special case. Ignoring parent classes when checking for an installed import avoids finding UNIVERSAL::import.